### PR TITLE
fix(IRouter): return types

### DIFF
--- a/libs/routers/src/IRouter.ts
+++ b/libs/routers/src/IRouter.ts
@@ -1,9 +1,9 @@
 import type { File, StringRecord, RequestBodyData } from '@cordis/rest';
 
 export type IRouter = {
-  get<T, Q extends StringRecord | string = StringRecord>(options?: { query?: Q }): T;
-  delete<T, D extends RequestBodyData = RequestBodyData>(options?: { data?: D; reason?: string }): T;
-  patch<T, D extends RequestBodyData>(options: { data: D; reason?: string }): T;
-  put<T, D extends RequestBodyData>(options: { data: D; reason?: string }): T;
-  post<T, D extends RequestBodyData>(options: { data: D; reason?: string; files?: File[] }): T;
+  get<T, Q extends StringRecord | string = StringRecord>(options?: { query?: Q }): Promise<T>;
+  delete<T, D extends RequestBodyData = RequestBodyData>(options?: { data?: D; reason?: string }): Promise<T>;
+  patch<T, D extends RequestBodyData>(options: { data: D; reason?: string }): Promise<T>;
+  put<T, D extends RequestBodyData>(options: { data: D; reason?: string }): Promise<T>;
+  post<T, D extends RequestBodyData>(options: { data: D; reason?: string; files?: File[] }): Promise<T>;
 } & { [key: string]: IRouter };

--- a/libs/routers/src/restRouter.test.ts
+++ b/libs/routers/src/restRouter.test.ts
@@ -16,8 +16,8 @@ afterEach(() => {
   mockedMake.mockClear();
 });
 
-test('basic routing', () => {
-  router.users['123'].get();
+test('basic routing', async () => {
+  await router.users['123'].get();
 
   expect(mockedMake).toHaveBeenCalledTimes(1);
   expect(mockedMake).toHaveBeenCalledWith({ method: 'get', path: '/users/123' });


### PR DESCRIPTION
`IRouter` methods used to return `T`, but this is incorrect. An `IRouter` implementation will never be sync, this is HTTP we're talking about.