### PR TITLE
chore: remove redundant methods from redis-store

### DIFF
--- a/libs/redis-store/src/index.ts
+++ b/libs/redis-store/src/index.ts
@@ -139,15 +139,6 @@ export class RedisStore<T> implements IStore<T> {
     return this.decode(data);
   }
 
-  /**
-   * Retrieves multiple keys from Redis using a single hmget call.
-   * @param keys The keys to retrieve
-   * @returns An array of the values
-   */
-  public async getM(...keys: string[]) {
-    const data = await this.redis.hmget(this.hash, ...keys);
-    return data.map(e => e ? this.decode(e) : null);
-  }
 
   public async set(key: string, value: T) {
     const size = await this.redis.hlen(this.hash);
@@ -160,10 +151,6 @@ export class RedisStore<T> implements IStore<T> {
   public async delete(key: string) {
     const count = await this.redis.hdel(this.hash, key);
     return count > 0;
-  }
-
-  public deleteM(...keys: string[]) {
-    return this.redis.hdel(this.hash, ...keys);
   }
 
   public async findKey(cb: StoreSingleEntryCallback<T>) {

--- a/libs/redis-store/src/index.ts
+++ b/libs/redis-store/src/index.ts
@@ -139,7 +139,6 @@ export class RedisStore<T> implements IStore<T> {
     return this.decode(data);
   }
 
-
   public async set(key: string, value: T) {
     const size = await this.redis.hlen(this.hash);
     if (this.maxSize && size >= this.maxSize) await this.empty();
@@ -207,13 +206,10 @@ export class RedisStore<T> implements IStore<T> {
   }
 
   public async map<V = T>(cb: StoreMapCallback<V, T>) {
-    const raw = await this.redis.hgetall(this.hash);
-    return Object
-      .entries(raw)
-      .map(([key, value]) => cb(
-        this.decode(value),
-        key
-      ));
+    const output: V[] = [];
+    for await (const [key, value] of this) output.push(cb(value, key));
+
+    return output;
   }
 
   public async empty(cb?: StoreSingleEntryCallback<T>) {


### PR DESCRIPTION
Closes #22

This PR removes some methods that aren't necessary with the usage of pipelines.

Also, on second thought, there's nothing that the store can really implement in terms of pipelines. Just use `<RedisStore>.redis.pipeline()`.

NOTE: This change is not a patch - do NOT merge yet.