### PR TITLE
fix(Cluster): redis store construction

### DIFF
--- a/libs/gateway/src/websocket/Cluster.ts
+++ b/libs/gateway/src/websocket/Cluster.ts
@@ -193,7 +193,7 @@ export class Cluster extends EventEmitter {
       ...shardOptions
     } = options;
 
-    this.guilds = redis ? new RedisStore({ redis, hash: 'guilds' }) : new Store<APIGuild>();
+    this.guilds = redis ? new RedisStore({ redis, hash: 'guilds', encode: JSON.stringify, decode: JSON.parse }) : new Store<APIGuild>();
     this.rest = new RestManager(auth, { mutex: redis ? new RedisMutex(redis) : new MemoryMutex() });
     this.shardCount = shardCount;
     this.startingShard = startingShard;


### PR DESCRIPTION
This PR fixes an issue where guild objects would've likely been kept as `[object Object]`, or however IORedis decided to handle the objects we were throwing at it.