### PR TITLE
emergency fix for docs deploy workflow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -32,7 +32,7 @@ jobs:
         run: pnpm run build
         
       - name: Place CNAME
-        run: echo "cordis.didinele.me" > ./doc/CNAME
+        run: echo "cordis.didinele.me" >| ./doc/CNAME
 
       - name: Build the docs
         run: pnpm run docs

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -30,6 +30,9 @@ jobs:
 
       - name: Build the code
         run: pnpm run build
+        
+      - name: Place CNAME
+        run: echo "cordis.didinele.me" > ./doc/CNAME
 
       - name: Build the docs
         run: pnpm run docs


### PR DESCRIPTION
The docs are not currently avaliable at https://cordis.didinele.me due to an oversight that resulted in the CNAME file not being placed in the built docs before being pushed.

This PR will resolve that.