### PR TITLE
fix(functions/test): halt test can no longer randomly fail

### DIFF
--- a/libs/common/src/functions/functions.test.ts
+++ b/libs/common/src/functions/functions.test.ts
@@ -9,10 +9,18 @@ test('get missing props', () => {
 });
 
 test('halt', async () => {
-  const timeStart = Date.now();
+  jest.useFakeTimers();
 
-  await halt(100);
-  expect(Date.now() - timeStart).toBeGreaterThanOrEqual(100);
+  const cb = jest.fn();
+
+  const promise = halt(100).then(cb);
+  expect(setTimeout).toHaveBeenCalled();
+  expect(cb).not.toHaveBeenCalled();
+
+  jest.runAllTimers();
+
+  await promise;
+  expect(cb).toHaveBeenCalled();
 });
 
 describe('is promise', () => {


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This PR fixes an issue with the test for the `halt` function, that would rely on actual non-mocked `setTimeout` and `Date.now`, causing inconsistent and unpredictable failure at random times.

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes