### PR TITLE
replace cordis.didinele.me with cordis.js.org

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
     <br />
     <h3>
       <strong>
-        <a href="https://cordis.didinele.me/">Explore the docs »</a><a href="https://discord.gg/37ysd5dPYk"> Join Our Discord!</a>
+        <a href="https://cordis.js.org/">Explore the docs »</a><a href="https://discord.gg/37ysd5dPYk"> Join Our Discord!</a>
       </strong>
     </h2>
   </p>  

--- a/libs/bitfield/README.md
+++ b/libs/bitfield/README.md
@@ -12,7 +12,7 @@ Data structure for working with bitfields.
 - `yarn add @cordis/bitfield`
 
 ## Documentation
-You can find documentation for the whole project over at https://cordis.didinele.me
+You can find documentation for the whole project over at https://cordis.js.org
 
 ## Contributing
 Please see the main [README.md](https://github.com/cordis-lib/cordis) for info on how to contribute to this package or the other `@cordis` packages.

--- a/libs/brokers/README.md
+++ b/libs/brokers/README.md
@@ -12,7 +12,7 @@ A library containing message brokers for all sorts of patterns & protocols
 - `yarn add @cordis/brokers`
 
 ## Documentation
-You can find documentation for the whole project over at https://cordis.didinele.me
+You can find documentation for the whole project over at https://cordis.js.org
 
 ## Contributing
 Please see the main [README.md](https://github.com/cordis-lib/cordis) for info on how to contribute to this package or the other `@cordis` packages.

--- a/libs/common/README.md
+++ b/libs/common/README.md
@@ -12,7 +12,7 @@ A library containing cordis utility functions/types/structures.
 - `yarn add @cordis/common`
 
 ## Documentation
-You can find documentation for the whole project over at https://cordis.didinele.me
+You can find documentation for the whole project over at https://cordis.js.org
 
 ## Contributing
 Please see the main [README.md](https://github.com/cordis-lib/cordis) for info on how to contribute to this package or the other `@cordis` packages.

--- a/libs/error/README.md
+++ b/libs/error/README.md
@@ -12,7 +12,7 @@ A library for easily creating error classes with pre-defined messages.
 - `yarn add @cordis/error`
 
 ## Documentation
-You can find documentation for the whole project over at https://cordis.didinele.me
+You can find documentation for the whole project over at https://cordis.js.org
 
 ## Contributing
 Please see the main [README.md](https://github.com/cordis-lib/cordis) for info on how to contribute to this package or the other `@cordis` packages.

--- a/libs/gateway/README.md
+++ b/libs/gateway/README.md
@@ -38,7 +38,7 @@ main();
 ```
 
 ## Documentation
-You can find documentation for the whole project over at https://cordis.didinele.me
+You can find documentation for the whole project over at https://cordis.js.org
 
 ## Contributing
 Please see the main [README.md](https://github.com/cordis-lib/cordis) for info on how to contribute to this package or the other `@cordis` packages.

--- a/libs/queue/README.md
+++ b/libs/queue/README.md
@@ -12,7 +12,7 @@ Simple and sequential queue for async operations.
 - `yarn add @cordis/queue`
 
 ## Documentation
-You can find documentation for the whole project over at https://cordis.didinele.me
+You can find documentation for the whole project over at https://cordis.js.org
 
 ## Contributing
 Please see the main [README.md](https://github.com/cordis-lib/cordis) for info on how to contribute to this package or the other `@cordis` packages.

--- a/libs/redis-store/README.md
+++ b/libs/redis-store/README.md
@@ -14,7 +14,7 @@ This package implements [`@cordis/store`](https://github.com/cordis-lib/cordis/t
 - `yarn add @cordis/redis-store`
 
 ## Documentation
-You can find documentation for the whole project over at https://cordis.didinele.me
+You can find documentation for the whole project over at https://cordis.js.org
 
 ## Contributing
 Please see the main [README.md](https://github.com/cordis-lib/cordis) for info on how to contribute to this package or the other `@cordis` packages.

--- a/libs/rest/README.md
+++ b/libs/rest/README.md
@@ -33,7 +33,7 @@ main();
 ```
 
 ## Documentation
-You can find documentation for the whole project over at https://cordis.didinele.me
+You can find documentation for the whole project over at https://cordis.js.org
 
 ## Contributing
 Please see the main [README.md](https://github.com/cordis-lib/cordis) for info on how to contribute to this package or the other `@cordis` packages.

--- a/libs/routers/README.md
+++ b/libs/routers/README.md
@@ -24,7 +24,7 @@ console.log(user);
 ```
 
 ## Documentation
-You can find documentation for the whole project over at https://cordis.didinele.me
+You can find documentation for the whole project over at https://cordis.js.org
 
 ## Contributing
 Please see the main [README.md](https://github.com/cordis-lib/cordis) for info on how to contribute to this package or the other `@cordis` packages.

--- a/libs/snowflake/README.md
+++ b/libs/snowflake/README.md
@@ -12,7 +12,7 @@ Simple package for destructuring (Twitter) Discord snowflakes.
 - `yarn add @cordis/snowflake`
 
 ## Documentation
-You can find documentation for the whole project over at https://cordis.didinele.me
+You can find documentation for the whole project over at https://cordis.js.org
 
 ## Contributing
 Please see the main [README.md](https://github.com/cordis-lib/cordis) for info on how to contribute to this package or the other `@cordis` packages.

--- a/libs/store/README.md
+++ b/libs/store/README.md
@@ -14,7 +14,7 @@ This package implements a simple in-memory store that actually extends the stand
 - `yarn add @cordis/store`
 
 ## Documentation
-You can find documentation for the whole project over at https://cordis.didinele.me
+You can find documentation for the whole project over at https://cordis.js.org
 
 ## Contributing
 Please see the main [README.md](https://github.com/cordis-lib/cordis) for info on how to contribute to this package or the other `@cordis` packages.


### PR DESCRIPTION
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
