### PR TITLE
fix(util): add discord-api-types dependency

### DIFF
--- a/libs/util/package.json
+++ b/libs/util/package.json
@@ -34,8 +34,9 @@
     "typescript": "^4.2.2"
   },
   "dependencies": {
-    "@cordis/rest": "workspace:^0.2.0",
     "@cordis/error": "workspace:^0.2.0",
+    "@cordis/rest": "workspace:^0.2.0",
+    "discord-api-types": "^0.12.1",
     "tslib": "^2.1.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -210,6 +210,7 @@ importers:
     dependencies:
       '@cordis/error': link:../error
       '@cordis/rest': link:../rest
+      discord-api-types: 0.12.1
       tslib: 2.1.0
     devDependencies:
       '@types/node': 14.14.31
@@ -218,6 +219,7 @@ importers:
       '@cordis/error': workspace:^0.2.0
       '@cordis/rest': workspace:^0.2.0
       '@types/node': ^14.14.31
+      discord-api-types: ^0.12.1
       tslib: ^2.1.0
       typescript: ^4.2.2
   services/gateway:


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
`discord-api-types` was apparently not declared as a dependency in `@cordis/util` leading to runtime errors when attempting to import it on package managers that don't use flat node_modules structures, or, in general, if it just wasn't installed from something else.

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes