### PR TITLE
chore: polish rest

### DIFF
--- a/libs/rest/src/Error.ts
+++ b/libs/rest/src/Error.ts
@@ -6,7 +6,8 @@ export const CordisRestError = makeCordisError(
   Error,
   {
     retryLimitExceeded: (request: string, attempts: number) => `Tried to "${request}" for ${attempts} times but all of them failed`,
-    rateLimited: (request: string) => `A ratelimit was hit while "${request}"`,
+    mutexLock: (route: string) => `A mutex for the "${route}" bucket locked up but was told to not wait`,
+    rateLimited: (request: string) => `A ratelimit was hit/prevented while "${request}"`,
     internal: (request: string) => `Discord raised an internal error on "${request}"`
   }
 );

--- a/libs/rest/src/Fetch.ts
+++ b/libs/rest/src/Fetch.ts
@@ -33,6 +33,7 @@ export interface DiscordFetchOptions<D = RequestBodyData, Q = StringRecord> {
   headers: Headers;
   controller: AbortController;
   implicitAbortBehavior: boolean;
+  retryAfterRatelimit: boolean;
   query?: Q | string;
   files?: File[];
   data?: D;

--- a/libs/rest/src/Fetch.ts
+++ b/libs/rest/src/Fetch.ts
@@ -34,6 +34,7 @@ export interface DiscordFetchOptions<D = RequestBodyData, Q = StringRecord> {
   controller: AbortController;
   implicitAbortBehavior: boolean;
   retryAfterRatelimit: boolean;
+  isRetryAfterRatelimit: boolean;
   query?: Q | string;
   files?: File[];
   data?: D;

--- a/libs/rest/src/mutex/Mutex.ts
+++ b/libs/rest/src/mutex/Mutex.ts
@@ -1,4 +1,5 @@
 import { halt } from '@cordis/common';
+import { CordisRestError } from '../Error';
 import type { RatelimitData } from '../struct';
 
 /**
@@ -8,16 +9,21 @@ export abstract class Mutex {
   /**
    * "Claims" a route
    * @param route Route to claim
+   * @param wait Wether or not the function should wait for the limit or if it should simply throw
    * @returns A promise that resolves once it is safe to go through with the request - its value being the timeout
    */
-  public async claim(route: string) {
+  public async claim(route: string, wait = true) {
     let timeout = await this._getTimeout(route);
     let output = timeout;
 
-    while (timeout > 0) {
-      await halt(timeout);
-      timeout = await this._getTimeout(route);
-      output += timeout;
+    if (timeout > 0) {
+      if (!wait) return Promise.reject(new CordisRestError('mutexLock', route));
+
+      while (timeout > 0) {
+        await halt(timeout);
+        timeout = await this._getTimeout(route);
+        output += timeout;
+      }
     }
 
     return output;

--- a/libs/rest/src/mutex/Mutex.ts
+++ b/libs/rest/src/mutex/Mutex.ts
@@ -8,14 +8,19 @@ export abstract class Mutex {
   /**
    * "Claims" a route
    * @param route Route to claim
-   * @returns A promise that resolves once it is safe to go through with the request
+   * @returns A promise that resolves once it is safe to go through with the request - its value being the timeout
    */
   public async claim(route: string) {
     let timeout = await this._getTimeout(route);
+    let output = timeout;
+
     while (timeout > 0) {
       await halt(timeout);
       timeout = await this._getTimeout(route);
+      output += timeout;
     }
+
+    return output;
   }
 
   /**

--- a/libs/rest/src/mutex/RedisMutex.ts
+++ b/libs/rest/src/mutex/RedisMutex.ts
@@ -43,11 +43,11 @@ export class RedisMutex extends Mutex {
     const remaining = parseInt(rawRemaining);
 
     const ttl = await this.redis.pttl(this._keys.remaining(route));
-    if (remaining <= 0 && ttl >= 0) {
+    if (remaining <= 0 && ttl > 0) {
       return ttl;
     }
 
-    await this.redis.set(this._keys.remaining(route), Math.max(remaining - 1, limit - 1));
+    await this.redis.set(this._keys.remaining(route), remaining - 1);
     if (ttl > 0) await this.redis.pexpire(this._keys.remaining(route), ttl);
 
     return 0;

--- a/libs/rest/src/mutex/RedisMutex.ts
+++ b/libs/rest/src/mutex/RedisMutex.ts
@@ -43,12 +43,11 @@ export class RedisMutex extends Mutex {
     const remaining = parseInt(rawRemaining);
 
     const ttl = await this.redis.pttl(this._keys.remaining(route));
-    if (remaining <= 0) {
-      if (ttl <= 0) return 1e2;
+    if (remaining <= 0 && ttl >= 0) {
       return ttl;
     }
 
-    await this.redis.set(this._keys.remaining(route), remaining - 1);
+    await this.redis.set(this._keys.remaining(route), Math.max(remaining - 1, limit - 1));
     if (ttl > 0) await this.redis.pexpire(this._keys.remaining(route), ttl);
 
     return 0;

--- a/libs/rest/src/mutex/mutex.test.ts
+++ b/libs/rest/src/mutex/mutex.test.ts
@@ -32,7 +32,7 @@ test('setting nothing changes nothing', async () => {
 
   expect(mutex.set('foo', {})).toBeUndefined();
   expect(mutex.global).toBeNull();
-  expect(await mutex.claim('foo')).toBeUndefined();
+  expect(await mutex.claim('foo')).toBe(0);
 });
 
 test('setting only the timeout does not cause delay', async () => {

--- a/libs/rest/src/struct/Rest.ts
+++ b/libs/rest/src/struct/Rest.ts
@@ -110,6 +110,10 @@ export interface RequestOptions<D, Q> {
    * Wether or not this request should be re-attempted after a ratelimit is waited out
    */
   retryAfterRatelimit?: boolean;
+  /**
+   * Wether or not the library should internally set a timeout for the I/O call
+   */
+  implicitAbortBehavior?: boolean;
 }
 
 /**
@@ -163,7 +167,7 @@ export class Rest extends EventEmitter {
       this._buckets.set(route, bucket);
     }
 
-    const implicitAbortBehavior = !Boolean(options.controller);
+    options.implicitAbortBehavior ??= !Boolean(options.controller);
     options.controller ??= new AbortController();
     options.retryAfterRatelimit ??= this.retryAfterRatelimit;
 
@@ -174,7 +178,7 @@ export class Rest extends EventEmitter {
 
     for (let retries = 0; retries <= this.retries; retries++) {
       try {
-        return await bucket.make<T, D, Q>({ implicitAbortBehavior, ...options } as DiscordFetchOptions<D, Q>);
+        return await bucket.make<T, D, Q>(options as DiscordFetchOptions<D, Q>);
       } catch (e) {
         if (
           e instanceof HTTPError ||

--- a/libs/rest/src/struct/rest.test.ts
+++ b/libs/rest/src/struct/rest.test.ts
@@ -77,7 +77,10 @@ describe('buckets and rate limiting', () => {
       expect(req.headers).toBeInstanceOf(Headers);
       expect(data).toStrictEqual(JSON.parse(value));
       expect(emitter).toBeCalledTimes(2);
-      expect(emitter).toHaveBeenNthCalledWith(1, 'request', Object.assign(req, { implicitAbortBehavior: true }));
+      expect(emitter).toHaveBeenNthCalledWith(1, 'request', Object.assign(req, {
+        implicitAbortBehavior: true,
+        isRetryAfterRatelimit: false
+      }));
       expect(emitter).toHaveBeenLastCalledWith('response', req, res, { limit: 5, timeout: 2500 });
     });
 
@@ -123,10 +126,13 @@ describe('buckets and rate limiting', () => {
       for await (const piece of data.stream()) final += piece;
 
       expect(emitter).toBeCalledTimes(5);
-      expect(emitter).toHaveBeenNthCalledWith(1, 'request', Object.assign(req, { implicitAbortBehavior: true }));
+      expect(emitter).toHaveBeenNthCalledWith(1, 'request', Object.assign(req, {
+        implicitAbortBehavior: true,
+        isRetryAfterRatelimit: false
+      }));
       expect(emitter).toHaveBeenNthCalledWith(2, 'response', req, responses[0], { global: false, limit: 5, remaining: 0, timeout: 2500 });
       expect(emitter).toHaveBeenNthCalledWith(3, 'ratelimit', 'channels/12345678910111213', 'channels/12345678910111213', false, 2500);
-      expect(emitter).toHaveBeenNthCalledWith(4, 'request', req);
+      expect(emitter).toHaveBeenNthCalledWith(4, 'request', Object.assign(req, { isRetryAfterRatelimit: true }));
       expect(emitter).toHaveBeenNthCalledWith(5, 'response', req, responses[1], { limit: 5, timeout: 2500 });
 
       expect(JSON.parse(final)).toStrictEqual(JSON.parse(value));
@@ -172,7 +178,10 @@ describe('non 429 error recovery', () => {
 
       expect(data).toStrictEqual(JSON.parse(value));
       expect(emitter).toBeCalledTimes(4);
-      expect(emitter).toHaveBeenNthCalledWith(1, 'request', Object.assign(req, { implicitAbortBehavior: true }));
+      expect(emitter).toHaveBeenNthCalledWith(1, 'request', Object.assign(req, {
+        implicitAbortBehavior: true,
+        isRetryAfterRatelimit: false
+      }));
       expect(emitter).toHaveBeenNthCalledWith(2, 'response', req, responses[0], {});
       expect(emitter).toHaveBeenNthCalledWith(3, 'request', req);
       expect(emitter).toHaveBeenNthCalledWith(4, 'response', req, responses[1], { limit: 5, timeout: 2500 });
@@ -219,7 +228,10 @@ describe('non 429 error recovery', () => {
         .toThrow(CordisRestError);
 
       expect(emitter).toBeCalledTimes(8);
-      expect(emitter).toHaveBeenNthCalledWith(1, 'request', Object.assign(req, { implicitAbortBehavior: true }));
+      expect(emitter).toHaveBeenNthCalledWith(1, 'request', Object.assign(req, {
+        implicitAbortBehavior: true,
+        isRetryAfterRatelimit: false
+      }));
       expect(emitter).toHaveBeenNthCalledWith(2, 'response', req, responses[0], {});
       expect(emitter).toHaveBeenNthCalledWith(3, 'request', req);
       expect(emitter).toHaveBeenNthCalledWith(4, 'response', req, responses[1], {});
@@ -259,7 +271,10 @@ describe('non 429 error recovery', () => {
       .toThrow(HTTPError);
 
     expect(emitter).toBeCalledTimes(2);
-    expect(emitter).toHaveBeenNthCalledWith(1, 'request', Object.assign(req, { implicitAbortBehavior: true }));
+    expect(emitter).toHaveBeenNthCalledWith(1, 'request', Object.assign(req, {
+      implicitAbortBehavior: true,
+      isRetryAfterRatelimit: false
+    }));
     expect(emitter).toHaveBeenNthCalledWith(2, 'response', req, responses[0], { limit: 5, timeout: 2500 });
   });
 
@@ -289,6 +304,9 @@ describe('non 429 error recovery', () => {
       .toStrictEqual(err);
 
     expect(emitter).toBeCalledTimes(1);
-    expect(emitter).toHaveBeenNthCalledWith(1, 'request', Object.assign(req, { implicitAbortBehavior: false }));
+    expect(emitter).toHaveBeenNthCalledWith(1, 'request', Object.assign(req, {
+      implicitAbortBehavior: false,
+      isRetryAfterRatelimit: false
+    }));
   });
 });


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
- fix(Bucket): actually throw on prevented ratelimits when retryAfterRatelimit is false
- fix(RedisMutex): handle TTLs for the remaining key correctly (see #72)

Closes #72 

**Status and versioning classification:**
- This PR changes the library's interface (methods or parameters added)