### PR TITLE
Feat/consumer packet handling

### DIFF
--- a/libs/brokers/package.json
+++ b/libs/brokers/package.json
@@ -37,7 +37,6 @@
   "dependencies": {
     "@cordis/common": "workspace:^0.3.0",
     "@cordis/error": "workspace:^0.3.0",
-    "@cordis/store": "workspace:^0.3.0",
     "@msgpack/msgpack": "^2.4.0",
     "amqplib": "^0.6.0",
     "tslib": "^2.1.0"

--- a/libs/brokers/package.json
+++ b/libs/brokers/package.json
@@ -37,6 +37,7 @@
   "dependencies": {
     "@cordis/common": "workspace:^0.3.0",
     "@cordis/error": "workspace:^0.3.0",
+    "@cordis/store": "workspace:^0.3.0",
     "@msgpack/msgpack": "^2.4.0",
     "amqplib": "^0.6.0",
     "tslib": "^2.1.0"

--- a/libs/brokers/src/brokers/routing/RoutingClient.ts
+++ b/libs/brokers/src/brokers/routing/RoutingClient.ts
@@ -5,7 +5,7 @@ import type * as amqp from 'amqplib';
 /**
  * Options for initializing the routing client
  */
-export interface RoutingClientInitOtions<K extends string> {
+export interface RoutingClientInitOptions<K extends string> {
   /**
    * Name of the exchange to use
    */
@@ -69,7 +69,7 @@ export class RoutingClient<K extends string, T extends Record<K, any>> extends B
    * Initializes the client, binding the events you want to the queue
    * @param options Options used for this client
    */
-  public async init(options: RoutingClientInitOtions<K>) {
+  public async init(options: RoutingClientInitOptions<K>) {
     const { name, topicBased = false, keys, queue: rawQueue = '', nonceStore = new Store(), maxMessageAge = Infinity } = options;
 
     const exchange = await this.channel.assertExchange(name, topicBased ? 'topic' : 'direct', { durable: false }).then(d => d.exchange);

--- a/libs/brokers/src/brokers/routing/RoutingServer.ts
+++ b/libs/brokers/src/brokers/routing/RoutingServer.ts
@@ -48,7 +48,6 @@ export class RoutingServer<K extends string, T extends Record<K, any>> extends B
   public publish<LK extends K>(key: LK, content: T[LK], options: amqp.Options.Publish = {}) {
     if (!this.exchange) throw new CordisBrokerError('brokerNotInit');
 
-    options.correlationId ??= this.util.generateCorrelationId();
     options.timestamp ??= Date.now();
 
     return this.util.sendToExchange({

--- a/libs/brokers/src/brokers/routing/RoutingServer.ts
+++ b/libs/brokers/src/brokers/routing/RoutingServer.ts
@@ -45,8 +45,11 @@ export class RoutingServer<K extends string, T extends Record<K, any>> extends B
    * @param content Data to publish
    * @param options Message-specific options
    */
-  public publish<LK extends K>(key: LK, content: T[LK], options?: amqp.Options.Publish) {
+  public publish<LK extends K>(key: LK, content: T[LK], options: amqp.Options.Publish = {}) {
     if (!this.exchange) throw new CordisBrokerError('brokerNotInit');
+
+    options.correlationId ??= this.util.generateCorrelationId();
+    options.timestamp ??= Date.now();
 
     return this.util.sendToExchange({
       to: this.exchange,

--- a/libs/brokers/src/brokers/routing/routing.test.ts
+++ b/libs/brokers/src/brokers/routing/routing.test.ts
@@ -6,7 +6,6 @@ import type * as amqp from 'amqplib';
 
 jest.mock('amqplib', () => {
   const actual: typeof import('amqplib') = jest.requireActual('amqplib');
-  const crypto: typeof import('crypto') = jest.requireActual('crypto');
 
   return {
     ...actual,
@@ -18,7 +17,7 @@ jest.mock('amqplib', () => {
           .mockImplementation(() => ({ on }));
 
         let callback: (msg: amqp.ConsumeMessage | null) => void;
-        const props = { properties: { correlationId: crypto.randomBytes(16).toString('base64'), timestamp: Date.now() } } as any;
+        const props = { properties: { timestamp: Date.now() } } as any;
 
         return Promise.resolve({
           on,
@@ -88,8 +87,6 @@ describe('publishing', () => {
 
     server.publish('test', 'test');
 
-    await new Promise(res => setImmediate(res));
-
     expect(eventCb).toHaveBeenCalled();
   });
 
@@ -106,8 +103,6 @@ describe('publishing', () => {
     client.on('test', eventCb);
 
     server.publish('test', 'test');
-
-    await new Promise(res => setImmediate(res));
 
     expect(eventCb).toHaveBeenCalled();
   });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -69,6 +69,7 @@ importers:
     specifiers:
       '@cordis/common': workspace:^0.3.0
       '@cordis/error': workspace:^0.3.0
+      '@cordis/store': workspace:^0.3.0
       '@msgpack/msgpack': ^2.4.0
       '@types/amqplib': ^0.5.17
       '@types/node': ^14.14.31
@@ -78,6 +79,7 @@ importers:
     dependencies:
       '@cordis/common': link:../common
       '@cordis/error': link:../error
+      '@cordis/store': link:../store
       '@msgpack/msgpack': 2.4.0
       amqplib: 0.6.0
       tslib: 2.1.0


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This PR adds the following option to the `RoutingClient#init`
- `RoutingClientInitOptions#maxMessageAge` - defaulting to `Infinity`

By default, `maxMessageAge` being `Infinity` means you don't have to change anything in your codebase - however, I would suggest you do! This is fairly beneficial esp. for gateway users.

If your packet handlers die, currently... your bot may just play catchup with messages that could be.. as old as time! This new option allows you to set maximum age for a gateway packet before it should just be ignored.

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- This PR changes the library's interface (methods or parameters added)