### PR TITLE
refactor(Brokers): change confusing client/server naming to publisher/subscriber

### DIFF
--- a/libs/brokers/src/brokers/pubsub/PubSubPublisher.ts
+++ b/libs/brokers/src/brokers/pubsub/PubSubPublisher.ts
@@ -3,9 +3,9 @@ import { Broker } from '../Broker';
 import type * as amqp from 'amqplib';
 
 /**
- * Options for initializing the pub/sub server
+ * Options for initializing the pub/sub publisher
  */
-export interface PubSubServerInitOptions {
+export interface PubSubPublisherInitOptions {
   /**
    * Name of the queue/exchange to use
    */
@@ -17,9 +17,9 @@ export interface PubSubServerInitOptions {
 }
 
 /**
- * Server for simple publish/subscribe lasyout
+ * Publisher for simple publish/subscribe layout
  */
-export class PubSubServer<T> extends Broker {
+export class PubSubPublisher<T> extends Broker {
   public name?: string;
   public fanout?: boolean;
 
@@ -31,7 +31,7 @@ export class PubSubServer<T> extends Broker {
    * Initializes the client, making it ready to publish packets
    * @param options Options to use for the server
    */
-  public async init(options: PubSubServerInitOptions) {
+  public async init(options: PubSubPublisherInitOptions) {
     const { name, fanout = false } = options;
 
     this.name = fanout

--- a/libs/brokers/src/brokers/pubsub/PubSubSubscriber.ts
+++ b/libs/brokers/src/brokers/pubsub/PubSubSubscriber.ts
@@ -3,9 +3,9 @@ import type { ConsumeQueueCallback } from '../BrokerUtil';
 import type * as amqp from 'amqplib';
 
 /**
- * Options for initializing the pub/sub client
+ * Options for initializing the pub/sub consumer
  */
-export interface PubSubClientInitOptions<T> {
+export interface PubSubSubscriberInitOptions<T> {
   /**
    * Name of the queue/exchange to use
    */
@@ -21,9 +21,9 @@ export interface PubSubClientInitOptions<T> {
 }
 
 /**
- * Client for simple publish/subscribe lasyout
+ * Consumer for simple publish/subscribe layout
  */
-export class PubSubClient<T> extends Broker {
+export class PubSubSubscriber<T> extends Broker {
   public constructor(channel: amqp.Channel) {
     super(channel);
   }
@@ -32,7 +32,7 @@ export class PubSubClient<T> extends Broker {
    * Initializes the server, making it listen to incoming packets
    * @param options Options to use for the client
    */
-  public async init(options: PubSubClientInitOptions<T>) {
+  public async init(options: PubSubSubscriberInitOptions<T>) {
     const { fanout = false, cb } = options;
 
     const name = fanout

--- a/libs/brokers/src/brokers/pubsub/pubsub.test.ts
+++ b/libs/brokers/src/brokers/pubsub/pubsub.test.ts
@@ -1,5 +1,5 @@
-import { PubSubClient } from './PubSubClient';
-import { PubSubServer } from './PubSubServer';
+import { PubSubSubscriber } from './PubSubSubscriber';
+import { PubSubPublisher } from './PubSubPublisher';
 import { createAmqp } from '../../amqp';
 import { CordisBrokerError } from '../../error';
 import type * as amqp from 'amqplib';
@@ -52,13 +52,13 @@ jest.mock('amqplib', () => {
 });
 
 const eventCb = jest.fn(() => Promise.resolve());
-let client!: PubSubClient<string>;
-let server!: PubSubServer<string>;
+let client!: PubSubSubscriber<string>;
+let server!: PubSubPublisher<string>;
 
 beforeEach(async () => {
   const { channel } = await createAmqp('boop');
-  client = new PubSubClient(channel);
-  server = new PubSubServer(channel);
+  client = new PubSubSubscriber(channel);
+  server = new PubSubPublisher(channel);
 });
 
 afterEach(() => jest.clearAllMocks());

--- a/libs/brokers/src/brokers/routing/RoutingPublisher.ts
+++ b/libs/brokers/src/brokers/routing/RoutingPublisher.ts
@@ -5,7 +5,7 @@ import type * as amqp from 'amqplib';
 /**
  * Options for initializing the routing server
  */
-export interface RoutingServerInitOptions {
+export interface RoutingPublisherInitOptions {
   /**
    * Name of the exchange to use
    */
@@ -19,7 +19,7 @@ export interface RoutingServerInitOptions {
 /**
  * Server-side broker for routing packets using keys
  */
-export class RoutingServer<K extends string, T extends Record<K, any>> extends Broker {
+export class RoutingPublisher<K extends string, T extends Record<K, any>> extends Broker {
   /**
    * Exchange being used
    */
@@ -33,7 +33,7 @@ export class RoutingServer<K extends string, T extends Record<K, any>> extends B
    * Initializes the server
    * @param options Options used for this server
    */
-  public async init(options: RoutingServerInitOptions) {
+  public async init(options: RoutingPublisherInitOptions) {
     this.exchange = await this.channel
       .assertExchange(options.name, options.topicBased ? 'topic' : 'direct', { durable: false })
       .then(d => d.exchange);

--- a/libs/brokers/src/brokers/routing/RoutingSubscriber.ts
+++ b/libs/brokers/src/brokers/routing/RoutingSubscriber.ts
@@ -4,7 +4,7 @@ import type * as amqp from 'amqplib';
 /**
  * Options for initializing the routing client
  */
-export interface RoutingClientInitOptions<K extends string> {
+export interface RoutingSubscriberInitOptions<K extends string> {
   /**
    * Name of the exchange to use
    */
@@ -29,7 +29,7 @@ export interface RoutingClientInitOptions<K extends string> {
   maxMessageAge?: number;
 }
 
-export interface RoutingClient<K extends string, T extends Record<K, any>> extends Broker {
+export interface RoutingSubscriber<K extends string, T extends Record<K, any>> extends Broker {
   /**
    * Event used mostly for internal errors
    * @event
@@ -55,7 +55,7 @@ export interface RoutingClient<K extends string, T extends Record<K, any>> exten
 /**
  * Client-side broker for routing packets using keys
  */
-export class RoutingClient<K extends string, T extends Record<K, any>> extends Broker {
+export class RoutingSubscriber<K extends string, T extends Record<K, any>> extends Broker {
   public constructor(channel: amqp.Channel) {
     super(channel);
   }
@@ -64,7 +64,7 @@ export class RoutingClient<K extends string, T extends Record<K, any>> extends B
    * Initializes the client, binding the events you want to the queue
    * @param options Options used for this client
    */
-  public async init(options: RoutingClientInitOptions<K>) {
+  public async init(options: RoutingSubscriberInitOptions<K>) {
     const { name, topicBased = false, keys, queue: rawQueue = '', maxMessageAge = Infinity } = options;
 
     const exchange = await this.channel.assertExchange(name, topicBased ? 'topic' : 'direct', { durable: false }).then(d => d.exchange);

--- a/libs/brokers/src/brokers/routing/routing.test.ts
+++ b/libs/brokers/src/brokers/routing/routing.test.ts
@@ -1,5 +1,5 @@
-import { RoutingClient } from './RoutingClient';
-import { RoutingServer } from './RoutingServer';
+import { RoutingSubscriber } from './RoutingSubscriber';
+import { RoutingPublisher } from './RoutingPublisher';
 import { createAmqp } from '../../amqp';
 import { CordisBrokerError } from '../../error';
 import type * as amqp from 'amqplib';
@@ -58,13 +58,13 @@ interface Data {
 }
 
 const eventCb = jest.fn();
-let client!: RoutingClient<keyof Data, Data>;
-let server!: RoutingServer<keyof Data, Data>;
+let client!: RoutingSubscriber<keyof Data, Data>;
+let server!: RoutingPublisher<keyof Data, Data>;
 
 beforeEach(async () => {
   const { channel } = await createAmqp('boop');
-  client = new RoutingClient(channel);
-  server = new RoutingServer(channel);
+  client = new RoutingSubscriber(channel);
+  server = new RoutingPublisher(channel);
 });
 
 afterEach(() => jest.clearAllMocks());

--- a/libs/brokers/src/brokers/rpc/RpcPublisher.ts
+++ b/libs/brokers/src/brokers/rpc/RpcPublisher.ts
@@ -5,7 +5,7 @@ import type * as amqp from 'amqplib';
 /**
  * Options for initializing the RPC client
  */
-export interface RpcClientInitOptions {
+export interface RpcPublisherInitOptions {
   /**
    * Queue the server should be recieving requests on
    */
@@ -20,7 +20,7 @@ export interface RpcClientInitOptions {
  * Client-side broker for a simple RPC layout
  */
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
-export interface RpcClient<S, C> extends Broker {
+export interface RpcPublisher<S, C> extends Broker {
   /**
    * Event used mostly for internal errors
    * @event
@@ -45,7 +45,7 @@ export interface RpcClient<S, C> extends Broker {
 /**
  * Client-side broker for a simple RPC layout
  */
-export class RpcClient<S, C> extends Broker {
+export class RpcPublisher<S, C> extends Broker {
   /**
    * Queue used to send requests to the server
    */
@@ -67,7 +67,7 @@ export class RpcClient<S, C> extends Broker {
    * Initializes the client, making it listen for reply packets
    * @param options Options used for this client
    */
-  public async init(options: RpcClientInitOptions) {
+  public async init(options: RpcPublisherInitOptions) {
     const { name, timeout = 1e4 } = options;
 
     this.serverQueue = await this.channel.assertQueue(name, { durable: false }).then(d => d.queue);

--- a/libs/brokers/src/brokers/rpc/RpcSubscriber.ts
+++ b/libs/brokers/src/brokers/rpc/RpcSubscriber.ts
@@ -4,12 +4,12 @@ import type * as amqp from 'amqplib';
 /**
  * Callback used for generating a server response from the client-given data
  */
-export type RpcServerCallback<C, S> = (content: C) => S | Promise<S>;
+export type RpcSubscriberCallback<C, S> = (content: C) => S | Promise<S>;
 
 /**
  * Options for initializing the RPC server
  */
-export interface RpcServerInitOptions<S, C> {
+export interface RpcSubscriberInitOptions<S, C> {
   /**
    * Queue the server should be recieving requests on
    */
@@ -17,13 +17,13 @@ export interface RpcServerInitOptions<S, C> {
   /**
    * The callback to run for each message
    */
-  cb: RpcServerCallback<C, S>;
+  cb: RpcSubscriberCallback<C, S>;
 }
 
 /**
  * Server-side broker for a simple RPC layout
  */
-export class RpcServer<S, C> extends Broker {
+export class RpcSubscriber<S, C> extends Broker {
   public constructor(channel: amqp.Channel) {
     super(channel);
   }
@@ -32,7 +32,7 @@ export class RpcServer<S, C> extends Broker {
    * Initializes the server, making it listen for packets
    * @param options Options used for this server
    */
-  public async init(options: RpcServerInitOptions<S, C>) {
+  public async init(options: RpcSubscriberInitOptions<S, C>) {
     const { name, cb } = options;
 
     const queue = await this.channel.assertQueue(name, { durable: false }).then(d => d.queue);

--- a/libs/brokers/src/brokers/rpc/rpc.test.ts
+++ b/libs/brokers/src/brokers/rpc/rpc.test.ts
@@ -1,5 +1,5 @@
-import { RpcClient } from './RpcClient';
-import { RpcServer } from './RpcServer';
+import { RpcPublisher } from './RpcPublisher';
+import { RpcSubscriber } from './RpcSubscriber';
 import { createAmqp } from '../../amqp';
 import { CordisBrokerError } from '../../error';
 import type * as amqp from 'amqplib';
@@ -80,13 +80,13 @@ jest.mock('amqplib', () => {
   };
 });
 
-let client!: RpcClient<string, string>;
-let server!: RpcServer<string, string>;
+let client!: RpcPublisher<string, string>;
+let server!: RpcSubscriber<string, string>;
 
 beforeEach(async () => {
   const { channel } = await createAmqp('boop');
-  client = new RpcClient(channel);
-  server = new RpcServer(channel);
+  client = new RpcPublisher(channel);
+  server = new RpcSubscriber(channel);
 });
 
 afterEach(() => jest.clearAllMocks());

--- a/libs/brokers/src/index.ts
+++ b/libs/brokers/src/index.ts
@@ -1,13 +1,13 @@
 export * from './brokers/Broker';
 
-export * from './brokers/pubsub/PubSubClient';
-export * from './brokers/pubsub/PubSubServer';
+export * from './brokers/pubsub/PubSubPublisher';
+export * from './brokers/pubsub/PubSubSubscriber';
 
-export * from './brokers/routing/RoutingClient';
-export * from './brokers/routing/RoutingServer';
+export * from './brokers/routing/RoutingPublisher';
+export * from './brokers/routing/RoutingSubscriber';
 
-export * from './brokers/rpc/RpcClient';
-export * from './brokers/rpc/RpcServer';
+export * from './brokers/rpc/RpcPublisher';
+export * from './brokers/rpc/RpcSubscriber';
 
 export * from './amqp';
 

--- a/services/gateway/src/index.ts
+++ b/services/gateway/src/index.ts
@@ -1,5 +1,5 @@
 import config from './args';
-import { createAmqp, RoutingServer } from '@cordis/brokers';
+import { createAmqp, RoutingPublisher } from '@cordis/brokers';
 import { Cluster } from '@cordis/gateway';
 import type { DiscordEvents } from '@cordis/common';
 
@@ -12,7 +12,7 @@ const main = async () => {
       process.exit(1);
     });
 
-  const service = new RoutingServer<keyof DiscordEvents, DiscordEvents>(channel);
+  const service = new RoutingPublisher<keyof DiscordEvents, DiscordEvents>(channel);
   const cluster = new Cluster(config.auth, config.ws);
 
   cluster


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This PR changes the inconsistent and confusing "client/server" naming into "publisher/subscriber", more accurately depicting what each class does.

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
