### PR TITLE
fix(GatewayService): parse for env once again

### DIFF
--- a/services/gateway/src/args.ts
+++ b/services/gateway/src/args.ts
@@ -24,6 +24,7 @@ export interface GatewayServiceConfig {
 }
 
 const { argv } = yargs
+  .env()
   .option('auth', {
     global: true,
     description: 'The token used to identify to Discord',


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This PR fixes a regression from #84 that caused env vars to be ignored by the gateway.

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes