### PR TITLE
fix(rest): move discord-api-types into runtime deps

### DIFF
--- a/libs/bitfield/package.json
+++ b/libs/bitfield/package.json
@@ -3,7 +3,7 @@
   "description": "Data structure for working with bitfields",
   "main": "./dist/index.js",
   "types": "./types/index.d.ts",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "scripts": {
     "lint": "eslint src --ext .ts",
     "build": "tsc"
@@ -34,7 +34,7 @@
     "typescript": "^4.3.5"
   },
   "dependencies": {
-    "@cordis/error": "workspace:^1.0.0",
+    "@cordis/error": "workspace:^1.0.1",
     "tslib": "^2.3.0"
   }
 }

--- a/libs/brokers/package.json
+++ b/libs/brokers/package.json
@@ -3,7 +3,7 @@
   "description": "Message broker library for the cordis micro-services, built for AMQP",
   "main": "./dist/index.js",
   "types": "./types/index.d.ts",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "scripts": {
     "lint": "eslint src --ext .ts",
     "build": "tsc"
@@ -35,8 +35,8 @@
     "typescript": "^4.3.5"
   },
   "dependencies": {
-    "@cordis/common": "workspace:^1.0.0",
-    "@cordis/error": "workspace:^1.0.0",
+    "@cordis/common": "workspace:^1.0.1",
+    "@cordis/error": "workspace:^1.0.1",
     "@msgpack/msgpack": "^2.7.0",
     "amqplib": "^0.6.0",
     "tslib": "^2.3.0"

--- a/libs/common/package.json
+++ b/libs/common/package.json
@@ -3,7 +3,7 @@
   "description": "Common things amongst the cordis infrastructure",
   "main": "./dist/index.js",
   "types": "./types/index.d.ts",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "scripts": {
     "lint": "eslint src --ext .ts",
     "build": "tsc"
@@ -35,7 +35,7 @@
     "typescript": "^4.3.5"
   },
   "dependencies": {
-    "@cordis/error": "workspace:^1.0.0",
+    "@cordis/error": "workspace:^1.0.1",
     "discord-api-types": "^0.20.2",
     "tslib": "^2.3.0"
   }

--- a/libs/error/package.json
+++ b/libs/error/package.json
@@ -3,7 +3,7 @@
   "description": "Package for creating error structures",
   "main": "./dist/index.js",
   "types": "./types/index.d.ts",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "scripts": {
     "lint": "eslint src --ext .ts",
     "build": "tsc"

--- a/libs/gateway/package.json
+++ b/libs/gateway/package.json
@@ -4,7 +4,7 @@
   "description": "The cordis gateway to Discord",
   "main": "./dist/index.js",
   "types": "./types/index.d.ts",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "scripts": {
     "lint": "eslint src --ext .ts",
     "build": "tsc"
@@ -38,11 +38,11 @@
     "zlib-sync": "^0.1.7"
   },
   "dependencies": {
-    "@cordis/bitfield": "workspace:^1.0.0",
-    "@cordis/common": "workspace:^1.0.0",
-    "@cordis/error": "workspace:^1.0.0",
-    "@cordis/queue": "workspace:^1.0.0",
-    "@cordis/rest": "workspace:^1.0.0",
+    "@cordis/bitfield": "workspace:^1.0.1",
+    "@cordis/common": "workspace:^1.0.1",
+    "@cordis/error": "workspace:^1.0.1",
+    "@cordis/queue": "workspace:^1.0.1",
+    "@cordis/rest": "workspace:^1.0.1",
     "common-tags": "^1.8.0",
     "discord-api-types": "^0.20.2",
     "tslib": "^2.3.0",

--- a/libs/queue/package.json
+++ b/libs/queue/package.json
@@ -3,7 +3,7 @@
   "description": "Async queues for sequential operations",
   "main": "./dist/index.js",
   "types": "./types/index.d.ts",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "scripts": {
     "lint": "eslint src --ext .ts",
     "build": "tsc"

--- a/libs/redis-store/package.json
+++ b/libs/redis-store/package.json
@@ -3,7 +3,7 @@
   "description": "Redis cache implementing the cordis Store",
   "main": "./dist/index.js",
   "types": "./types/index.d.ts",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "scripts": {
     "lint": "eslint src --ext .ts",
     "build": "tsc"
@@ -35,8 +35,8 @@
     "typescript": "^4.3.5"
   },
   "dependencies": {
-    "@cordis/error": "workspace:^1.0.0",
-    "@cordis/store": "workspace:^1.0.0",
+    "@cordis/error": "workspace:^1.0.1",
+    "@cordis/store": "workspace:^1.0.1",
     "tslib": "^2.3.0"
   }
 }

--- a/libs/rest/package.json
+++ b/libs/rest/package.json
@@ -32,7 +32,6 @@
   "devDependencies": {
     "@types/node": "^14.17.5",
     "@types/node-fetch": "^2.5.11",
-    "discord-api-types": "^0.20.2",
     "fetch-blob": "^2.1.2",
     "typescript": "^4.3.5"
   },
@@ -40,6 +39,7 @@
     "@cordis/common": "workspace:^1.0.0",
     "@cordis/error": "workspace:^1.0.0",
     "abort-controller": "^3.0.0",
+    "discord-api-types": "^0.20.2",
     "form-data": "^3.0.1",
     "node-fetch": "^2.6.1",
     "tslib": "^2.3.0"

--- a/libs/rest/package.json
+++ b/libs/rest/package.json
@@ -4,7 +4,7 @@
   "description": "Cordis' REST utilities for the Discord API",
   "main": "./dist/index.js",
   "types": "./types/index.d.ts",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "scripts": {
     "lint": "eslint src --ext .ts",
     "build": "tsc"
@@ -36,8 +36,8 @@
     "typescript": "^4.3.5"
   },
   "dependencies": {
-    "@cordis/common": "workspace:^1.0.0",
-    "@cordis/error": "workspace:^1.0.0",
+    "@cordis/common": "workspace:^1.0.1",
+    "@cordis/error": "workspace:^1.0.1",
     "abort-controller": "^3.0.0",
     "discord-api-types": "^0.20.2",
     "form-data": "^3.0.1",

--- a/libs/store/package.json
+++ b/libs/store/package.json
@@ -3,7 +3,7 @@
   "description": "Map-based storage structure",
   "main": "./dist/index.js",
   "types": "./types/index.d.ts",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "scripts": {
     "lint": "eslint src --ext .ts",
     "build": "tsc"
@@ -34,7 +34,7 @@
     "typescript": "^4.3.5"
   },
   "dependencies": {
-    "@cordis/error": "workspace:^1.0.0",
+    "@cordis/error": "workspace:^1.0.1",
     "tslib": "^2.3.0"
   }
 }

--- a/libs/util/package.json
+++ b/libs/util/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cordis/util",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Helper methods and structures for Cordis",
   "main": "./dist/index.js",
   "types": "./types/index.d.ts",
@@ -34,8 +34,8 @@
     "typescript": "^4.3.5"
   },
   "dependencies": {
-    "@cordis/error": "workspace:^1.0.0",
-    "@cordis/rest": "workspace:^1.0.0",
+    "@cordis/error": "workspace:^1.0.1",
+    "@cordis/rest": "workspace:^1.0.1",
     "discord-api-types": "^0.20.2",
     "tslib": "^2.3.0"
   }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json.schemastore.org/package",
   "name": "cordis",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "A modular, micros-service based Discord API wrapper",
   "scripts": {
     "build": "pnpm recursive run build --filter @cordis/*",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -60,7 +60,7 @@ importers:
 
   libs/bitfield:
     specifiers:
-      '@cordis/error': workspace:^1.0.0
+      '@cordis/error': workspace:^1.0.1
       '@types/node': ^14.17.5
       tslib: ^2.3.0
       typescript: ^4.3.5
@@ -73,8 +73,8 @@ importers:
 
   libs/brokers:
     specifiers:
-      '@cordis/common': workspace:^1.0.0
-      '@cordis/error': workspace:^1.0.0
+      '@cordis/common': workspace:^1.0.1
+      '@cordis/error': workspace:^1.0.1
       '@msgpack/msgpack': ^2.7.0
       '@types/amqplib': ^0.5.17
       '@types/node': ^14.17.5
@@ -94,7 +94,7 @@ importers:
 
   libs/common:
     specifiers:
-      '@cordis/error': workspace:^1.0.0
+      '@cordis/error': workspace:^1.0.1
       '@types/amqplib': ^0.5.17
       '@types/node': ^14.17.5
       discord-api-types: ^0.20.2
@@ -122,11 +122,11 @@ importers:
 
   libs/gateway:
     specifiers:
-      '@cordis/bitfield': workspace:^1.0.0
-      '@cordis/common': workspace:^1.0.0
-      '@cordis/error': workspace:^1.0.0
-      '@cordis/queue': workspace:^1.0.0
-      '@cordis/rest': workspace:^1.0.0
+      '@cordis/bitfield': workspace:^1.0.1
+      '@cordis/common': workspace:^1.0.1
+      '@cordis/error': workspace:^1.0.1
+      '@cordis/queue': workspace:^1.0.1
+      '@cordis/rest': workspace:^1.0.1
       '@types/common-tags': ^1.8.1
       '@types/node': ^14.17.5
       '@types/ws': ^7.4.7
@@ -168,8 +168,8 @@ importers:
 
   libs/redis-store:
     specifiers:
-      '@cordis/error': workspace:^1.0.0
-      '@cordis/store': workspace:^1.0.0
+      '@cordis/error': workspace:^1.0.1
+      '@cordis/store': workspace:^1.0.1
       '@types/ioredis': ^4.26.6
       '@types/node': ^14.17.5
       tslib: ^2.3.0
@@ -185,8 +185,8 @@ importers:
 
   libs/rest:
     specifiers:
-      '@cordis/common': workspace:^1.0.0
-      '@cordis/error': workspace:^1.0.0
+      '@cordis/common': workspace:^1.0.1
+      '@cordis/error': workspace:^1.0.1
       '@types/node': ^14.17.5
       '@types/node-fetch': ^2.5.11
       abort-controller: ^3.0.0
@@ -212,7 +212,7 @@ importers:
 
   libs/store:
     specifiers:
-      '@cordis/error': workspace:^1.0.0
+      '@cordis/error': workspace:^1.0.1
       '@types/node': ^14.17.5
       tslib: ^2.3.0
       typescript: ^4.3.5
@@ -225,8 +225,8 @@ importers:
 
   libs/util:
     specifiers:
-      '@cordis/error': workspace:^1.0.0
-      '@cordis/rest': workspace:^1.0.0
+      '@cordis/error': workspace:^1.0.1
+      '@cordis/rest': workspace:^1.0.1
       '@types/node': ^14.17.5
       discord-api-types: ^0.20.2
       tslib: ^2.3.0
@@ -242,9 +242,9 @@ importers:
 
   services/gateway:
     specifiers:
-      '@cordis/brokers': workspace:^1.0.0
-      '@cordis/common': workspace:^1.0.0
-      '@cordis/gateway': workspace:^1.0.0
+      '@cordis/brokers': workspace:^1.0.1
+      '@cordis/common': workspace:^1.0.1
+      '@cordis/gateway': workspace:^1.0.1
       '@types/node': ^14.17.5
       '@types/yargs': ^15.0.14
       tslib: ^2.3.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -200,13 +200,13 @@ importers:
       '@cordis/common': link:../common
       '@cordis/error': link:../error
       abort-controller: 3.0.0
+      discord-api-types: 0.20.2
       form-data: 3.0.1
       node-fetch: 2.6.1
       tslib: 2.3.0
     devDependencies:
       '@types/node': 14.17.5
       '@types/node-fetch': 2.5.11
-      discord-api-types: 0.20.2
       fetch-blob: 2.1.2
       typescript: 4.3.5
 
@@ -3130,6 +3130,7 @@ packages:
   /discord-api-types/0.20.2:
     resolution: {integrity: sha512-DxjFGuiJ4q5oozYcw/KqAC9dUdGu5f8JIYee073/RMkXSKTYtx2Y7n7ha9FQO7alDfVUxElzdTuWt5ByzB+QKQ==}
     engines: {node: '>=12'}
+    dev: false
 
   /doctrine/3.0.0:
     resolution: {integrity: sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==}

--- a/services/gateway/package.json
+++ b/services/gateway/package.json
@@ -4,7 +4,7 @@
   "description": "Cordis' gateway service",
   "main": "./dist/index.js",
   "types": "./types/index.d.ts",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "scripts": {
     "lint": "eslint src --ext .ts",
     "build": "tsc"
@@ -22,14 +22,14 @@
   },
   "homepage": "https://github.com/cordis-lib/cordis#readme",
   "devDependencies": {
-    "@cordis/common": "workspace:^1.0.0",
+    "@cordis/common": "workspace:^1.0.1",
     "@types/node": "^14.17.5",
     "@types/yargs": "^15.0.14",
     "typescript": "^4.3.5"
   },
   "dependencies": {
-    "@cordis/brokers": "workspace:^1.0.0",
-    "@cordis/gateway": "workspace:^1.0.0",
+    "@cordis/brokers": "workspace:^1.0.1",
+    "@cordis/gateway": "workspace:^1.0.1",
     "tslib": "^2.3.0",
     "yargs": "^15.4.1"
   }


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This PR moves `discord-api-types` into the runtime dependencies for `@cordis/rest`, as it was being used for constants - causing a hard crash.

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes