### PR TITLE
fix(Bucket): group all invite routes into one bucket

### DIFF
--- a/libs/rest/src/struct/Bucket.ts
+++ b/libs/rest/src/struct/Bucket.ts
@@ -26,6 +26,7 @@ export class Bucket {
   public static makeRoute(method: string, url: string) {
     let route = url
       .replace(/\/([a-z-]+)\/(?:[0-9]{17,19})/g, (match, p) => (['channels', 'guilds', 'webhook'].includes(p) ? match : `/${p}/:id`))
+      .replace(/\/invites\/[\w\d-]{2,}/g, '/invites/:code')
       .replace(/\/reactions\/[^/]+/g, '/reactions/:id')
       .replace(/^\/webhooks\/(\d+)\/[A-Za-z0-9-_]{64,}/, '/webhooks/$1/:token')
       .replace(/\?.*$/, '');

--- a/libs/rest/src/struct/rest.test.ts
+++ b/libs/rest/src/struct/rest.test.ts
@@ -49,6 +49,9 @@ describe('buckets and rate limiting', () => {
 
     const first = Bucket.makeRoute('delete', '/channels/12345678910111213/messages/12345678910111213');
     expect(first).toBe('delete/channels/12345678910111213/messages/:id');
+
+    const invite = Bucket.makeRoute('get', '/invites/abcdefgh');
+    expect(invite).toBe('/invites/:code');
   });
 
   describe('make request', () => {


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This PR makes `Bucket#makeRoute` correctly group anything `/invites` related into a single ratelimiting bucket.


**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes