### PR TITLE
chore: remove router references

### DIFF
--- a/libs/rest/README.md
+++ b/libs/rest/README.md
@@ -15,23 +15,18 @@ Note: Props to https://github.com/spec-tacles/spectacles.js for the Mutex logic.
 
 ## Example Usage
 ```ts
-const { Rest, buildRestRouter } = require('@cordis/rest');
+const { Rest } = require('@cordis/rest');
 
 const main = async () => {
   const rest = new Rest('token');
-  const router = buildRestRouter(rest);
 
-  // using the rest manager itself
   const someUser = await rest.get('/users/223703707118731264');
   const someOtherUser = await rest.make({
     path: '/users/198536269586890752',
     method: 'get'
   });
 
-  // using the router utility
-  const someOtherOtherUser = await router.users["223703707118731264"].get();
-
-  console.log(someUser, someOtherUser, someOtherOtherUser);
+  console.log(someUser, someOtherUser);
 };
 
 main();


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Remove router references due to them being removed in #85 

**Status and versioning classification:**
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
