### PR TITLE
feat(Rest): caching support

### DIFF
--- a/libs/rest/src/Fetch.ts
+++ b/libs/rest/src/Fetch.ts
@@ -79,7 +79,7 @@ export const discordFetch = async <D, Q>(options: DiscordFetchOptions<D, Q>) => 
   }
 
   return fetch(url, {
-    method: method,
+    method,
     headers,
     body: body!,
     signal: controller.signal,

--- a/libs/rest/src/struct/Rest.ts
+++ b/libs/rest/src/struct/Rest.ts
@@ -247,7 +247,8 @@ export class Rest extends EventEmitter {
    * @param options Other options for the request
    */
   /* istanbul ignore next */
-  public get<T, Q = StringRecord>(path: string, options: { query?: Q } = {}): Promise<T> {
+
+  public get<T, Q = StringRecord>(path: string, options: { query?: Q; cache?: boolean; cacheTime?: number } = {}): Promise<T> {
     return this.make<T, never, Q>({ path, method: 'get', ...options });
   }
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This PR implements caching at the Rest class level, removing the need for a lot of awkward caching implementations I've built on the bot-level.

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- This PR changes the library's interface (methods or parameters added)
